### PR TITLE
Feature use left click for move tool

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -7,6 +7,7 @@
   <license>Apache 2.0</license>
 
   <maintainer email="h_ohta@tier4.jp">Hiroki OTA</maintainer>
+  <maintainer email="isamu.takagi@tier4.jp">Takagi, Isamu</maintainer>
 
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>roscpp</build_depend>

--- a/src/event_capture_tool.cpp
+++ b/src/event_capture_tool.cpp
@@ -13,10 +13,12 @@ namespace rviz_plugins {
 
 EventCapture::EventCapture()
 {
-    shortcut_key_ = 'c';
-    topic_property_.reset(new rviz::StringProperty( "Topic", "/rviz/event_capture/mouse",
-                                        "The topic on which to publish event capture",
-                                        getPropertyContainer(), SLOT( updateTopic() ), this ));
+  shortcut_key_ = 'c';
+  topic_property_.reset(new rviz::StringProperty( "Topic", "/rviz/event_capture/mouse",
+    "The topic on which to publish event capture",
+    getPropertyContainer(), SLOT( updateTopic() ), this ));
+  use_move_tool_property_.reset(new rviz::BoolProperty( "Use move tool", true,
+    "Use left click to control camera", getPropertyContainer() ));
 }
 
 EventCapture::~EventCapture()
@@ -46,21 +48,30 @@ void EventCapture::updateTopic()
 
 int EventCapture::processMouseEvent(rviz::ViewportMouseEvent& event)
 {
-  if(event.right() || event.rightDown() || event.rightUp())
+  if(use_move_tool_property_->getBool())
   {
-      publishMouseEvent(event);
+    if(event.right() || event.rightDown() || event.rightUp())
+    {
+        publishMouseEvent(event);
+    }
+    else
+    {
+        move_tool_.processMouseEvent(event);
+    }
   }
   else
   {
-      move_tool_.processMouseEvent(event);
+    publishMouseEvent(event);
   }
   return Render;
 }
 
-/*int EventCapture::processKeyEvent(QKeyEvent* event, rviz::RenderPanel* panel)
+/*
+int EventCapture::processKeyEvent(QKeyEvent* event, rviz::RenderPanel* panel)
 {
   return Render;
-}*/
+}
+*/
 
 void EventCapture::publishMouseEvent(rviz::ViewportMouseEvent &event)
 {

--- a/src/event_capture_tool.cpp
+++ b/src/event_capture_tool.cpp
@@ -25,6 +25,7 @@ EventCapture::~EventCapture()
 
 void EventCapture::onInitialize()
 {
+    move_tool_.initialize(context_);
     updateTopic();
 }
 
@@ -45,8 +46,15 @@ void EventCapture::updateTopic()
 
 int EventCapture::processMouseEvent(rviz::ViewportMouseEvent& event)
 {
-    publishMouseEvent(event);
-    return Render;
+  if(event.right() || event.rightDown() || event.rightUp())
+  {
+      publishMouseEvent(event);
+  }
+  else
+  {
+      move_tool_.processMouseEvent(event);
+  }
+  return Render;
 }
 
 /*int EventCapture::processKeyEvent(QKeyEvent* event, rviz::RenderPanel* panel)

--- a/src/event_capture_tool.hpp
+++ b/src/event_capture_tool.hpp
@@ -7,6 +7,7 @@
 #include <rviz/viewport_mouse_event.h>
 #include <rviz/properties/float_property.h>
 #include <rviz/properties/string_property.h>
+#include <rviz/properties/bool_property.h>
 #include <memory>
 
 
@@ -28,6 +29,7 @@ class EventCapture: public rviz::Tool
         //int processKeyEvent( QKeyEvent* event, rviz::RenderPanel* panel );
 
     private Q_SLOTS:
+
         void updateTopic();
 
     private:
@@ -36,6 +38,7 @@ class EventCapture: public rviz::Tool
         ros::NodeHandle nh_;
         ros::Publisher  pub_;
         std::unique_ptr<rviz::StringProperty> topic_property_;
+        std::unique_ptr<rviz::BoolProperty> use_move_tool_property_;
 
         void publishMouseEvent(rviz::ViewportMouseEvent &event);
 };

--- a/src/event_capture_tool.hpp
+++ b/src/event_capture_tool.hpp
@@ -3,6 +3,7 @@
 
 #include <ros/ros.h>
 #include <rviz/tool.h>
+#include <rviz/default_plugin/tools/move_tool.h>
 #include <rviz/viewport_mouse_event.h>
 #include <rviz/properties/float_property.h>
 #include <rviz/properties/string_property.h>
@@ -31,6 +32,7 @@ class EventCapture: public rviz::Tool
 
     private:
 
+        rviz::MoveTool move_tool_;
         ros::NodeHandle nh_;
         ros::Publisher  pub_;
         std::unique_ptr<rviz::StringProperty> topic_property_;


### PR DESCRIPTION
デフォルトでは左クリックをMoveTool用に使用するようにしました。
Tool Propertyのチェックボックスより従来の動作と切り替えられます。